### PR TITLE
Fixed "Bad CRC" errors (allows smaller builds to load on MiSTER)

### DIFF
--- a/patch_extra.bat
+++ b/patch_extra.bat
@@ -29,8 +29,12 @@ if %ERRORLEVEL% neq 0 (
 
 echo BUILD SUCCESS
 
-"%ASM%\chksum64.exe" "%ROM%" >> "%LOG%" 2>&1
-"%ASM%\rn64crc.exe" -u >> "%LOG%" 2>&1
+"%ASM%\rn64crc.exe" -u "%ROM%" >> "%LOG%" 2>&1
+if errorlevel 1 (
+    echo CRC UPDATE FAILED
+    type "%LOG%"
+    exit /b 1
+)
 
 echo Build log exported to "%LOG%"
 exit /b 0


### PR DESCRIPTION
After making this change, I was able to boot the game on a MiSTER core when I excluded enough stages and characters to get my build under 64 MB. It also made my EverDrive stop giving me a "Bad CRC" error.

Smash Bros uses CIC-NUS-6103, and chksum64 assumes the common 6102 algorithm and writes an invalid CRC1/CRC2 instead.