### PR TITLE
Fix Spider Man results screen crash caused by typo

### DIFF
--- a/extra_characters/Spiderman/config.yaml
+++ b/extra_characters/Spiderman/config.yaml
@@ -10,7 +10,7 @@ definitions:
 name: "Spider-Man"
 
 results:
-  name: "Spider-Man"
+  name: "Spider Man"
   name_scale: 0.65
   name_x: 20
   wins_x: 185


### PR DESCRIPTION

Spider-Man's results-screen name is currently configured as "Spider-Man". The Smash Remix results-screen character renderer does not handle -, the game crashes when Spider Man wins a match. 

# Fix

One-liner - change Spider-Man's results-screen name from:

name: "Spider-Man"

to:

name: "Spider Man"

The regular character name remains unchanged. This only affects the results-screen string.

# Reproduction
- Build +EXTRA with Spider-Man enabled.
- Start a VS match with Spider-Man.
- Win the match as Spider-Man.
- Enter the results screen.
- The series logo renders and the announcer says "This game's winner is..."
- The game crashes 

Spider Man being present in the match does not trigger the crash if another character wins. He must win. 


# Tested
Reproduced the crash before the change, then confirmed Spider Man can win and complete the results screen after the change with no crash. 